### PR TITLE
add_action('init', array(&$this, 'basic_auth'), 1);

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -39,7 +39,7 @@ RewriteRule ^(.*) - [E=HTTP_AUTHORIZATION:%1]
 ';
 
 	function __construct(){
-		add_action('template_redirect',array(&$this, 'basic_auth'));
+		add_action('init', array(&$this, 'basic_auth'), 1);
 
 		register_activation_hook(__FILE__, array(&$this, 'activate'));
 		register_deactivation_hook(__FILE__, array(&$this, 'deactivate'));


### PR DESCRIPTION
add action to init, and set $priority to 1 to ensure that this plugin was exec before some other plugins (such as json-api) to avoid escaping form authentication.
